### PR TITLE
Add support for Home Assistant discovery messages

### DIFF
--- a/src/app/src/main/java/com/health/openscale/sync/core/model/MQTTViewModel.kt
+++ b/src/app/src/main/java/com/health/openscale/sync/core/model/MQTTViewModel.kt
@@ -30,6 +30,7 @@ class MQTTViewModel(private val sharedPreferences: SharedPreferences) : ViewMode
     private val _mqttConnecting = MutableLiveData<Boolean>(false)
 
     private val _mqttUseSsl = MutableLiveData<Boolean>(sharedPreferences.getBoolean("mqtt_use_ssl", true))
+    private val _mqttUseDiscovery = MutableLiveData<Boolean>(sharedPreferences.getBoolean("mqtt_use_discovery", true))
 
     override fun getName(): String {
         return "MQTT"
@@ -73,5 +74,12 @@ class MQTTViewModel(private val sharedPreferences: SharedPreferences) : ViewMode
     fun setMqttUseSsl(useSsl: Boolean) {
         _mqttUseSsl.value = useSsl
         sharedPreferences.edit().putBoolean("mqtt_use_ssl", useSsl).apply()
+    }
+
+    val mqttUseDiscovery: LiveData<Boolean> = _mqttUseDiscovery
+
+    fun setMqttUseDiscovery(useDiscovery: Boolean) {
+        _mqttUseDiscovery.value = useDiscovery
+        sharedPreferences.edit().putBoolean("mqtt_use_discovery", useDiscovery).apply()
     }
 }

--- a/src/app/src/main/java/com/health/openscale/sync/core/sync/MQTTSync.kt
+++ b/src/app/src/main/java/com/health/openscale/sync/core/sync/MQTTSync.kt
@@ -30,7 +30,7 @@ class MQTTSync(private val mqttClient: Mqtt5BlockingClient) : SyncInterface() {
     fun fullSync(measurements: List<OpenScaleMeasurement>) : SyncResult<Unit> {
         var failureCount = 0
 
-        measurements.forEach { measurement ->
+        measurements.sortedBy { measurements -> measurements.id }.forEach { measurement ->
             val syncResult = publishMeasurement(measurement, "openScaleSync/measurements/insert")
 
             if (syncResult is SyncResult.Failure) {

--- a/src/app/src/main/res/raw/homeassistant_payload.json
+++ b/src/app/src/main/res/raw/homeassistant_payload.json
@@ -1,0 +1,60 @@
+{
+  "device": {
+    "name": "openScale",
+    "manufacturer": "oliexdev",
+    "identifiers": "openscale"
+  },
+  "origin": {
+    "name": "openScale sync",
+    "sw_version": "not_specified",
+    "support_url": "https://github.com/oliexdev/openScale-sync"
+  },
+  "components": {
+    "openscale_weight": {
+      "name": "Weight",
+      "platform": "sensor",
+      "device_class": "weight",
+      "unit_of_measurement": "kg",
+      "value_template": "{{ value_json.weight }}",
+      "unique_id": "openscale_weight"
+    },
+    "openscale_fat": {
+      "name": "Body fat",
+      "platform": "sensor",
+      "unit_of_measurement": "%",
+      "value_template": "{{ value_json.fat }}",
+      "unique_id": "openscale_fat"
+    },
+    "openscale_muscle": {
+      "name": "Muscle",
+      "platform": "sensor",
+      "unit_of_measurement": "%",
+      "value_template": "{{ value_json.muscle }}",
+      "unique_id": "openscale_muscle"
+    },
+    "openscale_water": {
+      "name": "Total body water",
+      "platform": "sensor",
+      "device_class": "moisture",
+      "unit_of_measurement": "%",
+      "value_template": "{{ value_json.water }}",
+      "unique_id": "openscale_water"
+    },
+    "openscale_measurement_date": {
+      "name": "Measurement date",
+      "platform": "sensor",
+      "entity_category": "diagnostic",
+      "device_class": "timestamp",
+      "value_template": "{{ value_json.date }}",
+      "unique_id": "openscale_date"
+    },
+    "openscale_measurement_id": {
+      "name": "Measurement id",
+      "platform": "sensor",
+      "entity_category": "diagnostic",
+      "value_template": "{{ value_json.id }}",
+      "unique_id": "openscale_id"
+    }
+  },
+  "state_topic": "openScaleSync/measurements/insert"
+}

--- a/src/app/src/main/res/values-de/strings.xml
+++ b/src/app/src/main/res/values-de/strings.xml
@@ -50,6 +50,7 @@
     <string name="mqtt_password_title">Passwort</string>
     <string name="mqtt_use_ssl_tls_title">SSL/TLS-Verschlüsselung verwenden</string>
     <string name="mqtt_ssl_disabled_warning">Warnung: Ohne SSL/TLS werden Daten unverschlüsselt gesendet. Nur für vertrauenswürdige lokale Netzwerke empfohlen.</string>
+    <string name="mqtt_use_discovery_tite">Home Assistant Discovery verwenden</string>
     <string name="mqtt_connecting_text">Verbinde …</string>
     <string name="mqtt_connect_to_mqtt_broker_button">Mit MQTT-Broker verbinden</string>
 

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -49,6 +49,7 @@
     <string name="mqtt_password_title">Password</string>
     <string name="mqtt_use_ssl_tls_title">Use SSL/TLS Encryption</string>
     <string name="mqtt_ssl_disabled_warning">Warning: Disabling SSL/TLS sends data unencrypted. Recommended for trusted local networks only.</string>
+    <string name="mqtt_use_discovery_tite">Use Home Assistant discovery</string>
     <string name="mqtt_connecting_text">Connecting …</string>
     <string name="mqtt_connect_to_mqtt_broker_button">Connect to MQTT broker</string>
 


### PR DESCRIPTION
Fixes #2

I don't have experience with android apps, any criticism is welcome.

What isn't implemented here is my last suggestion from that issue:

> As you might guess from the state_topic, this currently only works with inserts. It might make sense to introduce a openScaleSync/measurements/current topic, that's published to whenever the most recent measurement changes. Be that because one was deleted, updated, or inserted).