### PR TITLE
Add InfluxDB and Webhook sync backends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# VS Code
+.vscode/
+.claude/
+
 # Built application files
 *.apk
 *.ap_

--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -128,6 +128,7 @@ dependencies {
     implementation 'androidx.health.connect:connect-client:1.1.0-rc02'
     implementation 'com.hivemq:hivemq-mqtt-client:1.3.4'
     implementation 'com.google.code.gson:gson:2.10.1'
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'com.squareup.retrofit2:retrofit:2.8.1'
     implementation 'com.squareup.retrofit2:converter-gson:2.8.1'
 }

--- a/src/app/src/main/AndroidManifest.xml
+++ b/src/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="com.health.openscale.READ_WRITE_DATA" />
     <uses-permission android:name="com.health.openscale.debug.READ_WRITE_DATA" />
     <uses-permission android:name="com.health.openscale.oss.READ_WRITE_DATA" />

--- a/src/app/src/main/java/com/health/openscale/sync/core/datatypes/OpenScaleMeasurement.kt
+++ b/src/app/src/main/java/com/health/openscale/sync/core/datatypes/OpenScaleMeasurement.kt
@@ -29,8 +29,5 @@ data class OpenScaleMeasurement(
     val fat: Float,
     val water: Float,
     val muscle: Float,
-    val bone: Float = 0f,
-    val lbm: Float = 0f,
-    val visceralFat: Float = 0f,
-    val waist: Float = 0f
+    val extraFields: Map<String, Float> = emptyMap()
 )

--- a/src/app/src/main/java/com/health/openscale/sync/core/datatypes/OpenScaleMeasurement.kt
+++ b/src/app/src/main/java/com/health/openscale/sync/core/datatypes/OpenScaleMeasurement.kt
@@ -23,10 +23,14 @@ import java.util.Date
 @Keep
 data class OpenScaleMeasurement(
     val id: Int,
-    val userId : Int,
+    val userId: Int,
     val date: Date,
     val weight: Float,
     val fat: Float,
     val water: Float,
-    val muscle: Float
+    val muscle: Float,
+    val bone: Float = 0f,
+    val lbm: Float = 0f,
+    val visceralFat: Float = 0f,
+    val waist: Float = 0f
 )

--- a/src/app/src/main/java/com/health/openscale/sync/core/model/InfluxDbViewModel.kt
+++ b/src/app/src/main/java/com/health/openscale/sync/core/model/InfluxDbViewModel.kt
@@ -1,0 +1,53 @@
+package com.health.openscale.sync.core.model
+
+import android.content.SharedPreferences
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.health.openscale.sync.R
+
+class InfluxDbViewModel(private val sharedPreferences: SharedPreferences) : ViewModelInterface(sharedPreferences) {
+
+    private val _url = MutableLiveData<String>(sharedPreferences.getString("influxdb_url", "http://192.168.1.100:8086"))
+    private val _isV2 = MutableLiveData<Boolean>(sharedPreferences.getBoolean("influxdb_is_v2", true))
+    private val _org = MutableLiveData<String>(sharedPreferences.getString("influxdb_org", ""))
+    private val _bucket = MutableLiveData<String>(sharedPreferences.getString("influxdb_bucket", "openscale"))
+    private val _token = MutableLiveData<String>(sharedPreferences.getString("influxdb_token", ""))
+    private val _database = MutableLiveData<String>(sharedPreferences.getString("influxdb_database", "openscale"))
+    private val _dbUsername = MutableLiveData<String>(sharedPreferences.getString("influxdb_username", ""))
+    private val _dbPassword = MutableLiveData<String>(sharedPreferences.getString("influxdb_password", ""))
+    private val _measurement = MutableLiveData<String>(sharedPreferences.getString("influxdb_measurement", "openscale"))
+    private val _connecting = MutableLiveData<Boolean>(false)
+
+    override fun getName(): String = "InfluxDB"
+    override fun getIcon(): Int = R.drawable.ic_influxdb
+
+    val url: LiveData<String> = _url
+    fun setUrl(value: String) { _url.value = value; sharedPreferences.edit().putString("influxdb_url", value).apply() }
+
+    val isV2: LiveData<Boolean> = _isV2
+    fun setIsV2(value: Boolean) { _isV2.value = value; sharedPreferences.edit().putBoolean("influxdb_is_v2", value).apply() }
+
+    val org: LiveData<String> = _org
+    fun setOrg(value: String) { _org.value = value; sharedPreferences.edit().putString("influxdb_org", value).apply() }
+
+    val bucket: LiveData<String> = _bucket
+    fun setBucket(value: String) { _bucket.value = value; sharedPreferences.edit().putString("influxdb_bucket", value).apply() }
+
+    val token: LiveData<String> = _token
+    fun setToken(value: String) { _token.value = value; sharedPreferences.edit().putString("influxdb_token", value).apply() }
+
+    val database: LiveData<String> = _database
+    fun setDatabase(value: String) { _database.value = value; sharedPreferences.edit().putString("influxdb_database", value).apply() }
+
+    val dbUsername: LiveData<String> = _dbUsername
+    fun setDbUsername(value: String) { _dbUsername.value = value; sharedPreferences.edit().putString("influxdb_username", value).apply() }
+
+    val dbPassword: LiveData<String> = _dbPassword
+    fun setDbPassword(value: String) { _dbPassword.value = value; sharedPreferences.edit().putString("influxdb_password", value).apply() }
+
+    val measurement: LiveData<String> = _measurement
+    fun setMeasurement(value: String) { _measurement.value = value; sharedPreferences.edit().putString("influxdb_measurement", value).apply() }
+
+    val connecting: LiveData<Boolean> = _connecting
+    fun setConnecting(value: Boolean) { _connecting.value = value }
+}

--- a/src/app/src/main/java/com/health/openscale/sync/core/model/WebhookViewModel.kt
+++ b/src/app/src/main/java/com/health/openscale/sync/core/model/WebhookViewModel.kt
@@ -1,0 +1,21 @@
+package com.health.openscale.sync.core.model
+
+import android.content.SharedPreferences
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.health.openscale.sync.R
+
+class WebhookViewModel(private val sharedPreferences: SharedPreferences) : ViewModelInterface(sharedPreferences) {
+
+    private val _url = MutableLiveData<String>(sharedPreferences.getString("webhook_url", ""))
+    private val _authHeader = MutableLiveData<String>(sharedPreferences.getString("webhook_auth_header", ""))
+
+    override fun getName(): String = "Webhook"
+    override fun getIcon(): Int = R.drawable.ic_webhook
+
+    val url: LiveData<String> = _url
+    fun setUrl(value: String) { _url.value = value; sharedPreferences.edit().putString("webhook_url", value).apply() }
+
+    val authHeader: LiveData<String> = _authHeader
+    fun setAuthHeader(value: String) { _authHeader.value = value; sharedPreferences.edit().putString("webhook_auth_header", value).apply() }
+}

--- a/src/app/src/main/java/com/health/openscale/sync/core/provider/OpenScaleDataProvider.kt
+++ b/src/app/src/main/java/com/health/openscale/sync/core/provider/OpenScaleDataProvider.kt
@@ -150,34 +150,31 @@ class OpenScaleDataProvider(
                 var fat: Float? = null
                 var water: Float? = null
                 var muscle: Float? = null
-                var bone = 0f
-                var lbm = 0f
-                var visceralFat = 0f
-                var waist = 0f
+                val extraFields = mutableMapOf<String, Float>()
                 val userId = openScaleUser.id
 
                 for (i in 0 until record.columnCount) {
-                    when (record.getColumnName(i)) {
-                        "_ID"          -> id = record.getInt(i)
-                        "datetime"     -> dateTime = Date(record.getLong(i))
-                        "weight"       -> weight = roundFloat(record.getFloat(i))
-                        "fat"          -> fat = roundFloat(record.getFloat(i))
-                        "water"        -> water = roundFloat(record.getFloat(i))
-                        "muscle"       -> muscle = roundFloat(record.getFloat(i))
-                        "bone"         -> bone = roundFloat(record.getFloat(i))
-                        "lbm"          -> lbm = roundFloat(record.getFloat(i))
-                        "visceral_fat" -> visceralFat = roundFloat(record.getFloat(i))
-                        "waist"        -> waist = roundFloat(record.getFloat(i))
+                    val col = record.getColumnName(i)
+                    when (col) {
+                        "_ID"      -> id = record.getInt(i)
+                        "datetime" -> dateTime = Date(record.getLong(i))
+                        "weight"   -> weight = roundFloat(record.getFloat(i))
+                        "fat"      -> fat = roundFloat(record.getFloat(i))
+                        "water"    -> water = roundFloat(record.getFloat(i))
+                        "muscle"   -> muscle = roundFloat(record.getFloat(i))
+                        else -> {
+                            val type = record.getType(i)
+                            if (type == android.database.Cursor.FIELD_TYPE_FLOAT ||
+                                type == android.database.Cursor.FIELD_TYPE_INTEGER) {
+                                val value = roundFloat(record.getFloat(i))
+                                if (value != 0f) extraFields[col] = value
+                            }
+                        }
                     }
                 }
 
                 if (id != null && dateTime != null && weight != null && fat != null && water != null && muscle != null) {
-                    val measurement = OpenScaleMeasurement(
-                        id, userId, dateTime, weight, fat, water, muscle,
-                        bone, lbm, visceralFat, waist
-                    )
-
-                    measurements.add(measurement)
+                    measurements.add(OpenScaleMeasurement(id, userId, dateTime, weight, fat, water, muscle, extraFields))
                 } else {
                     Timber.e("Not all required parameters are set")
                 }

--- a/src/app/src/main/java/com/health/openscale/sync/core/provider/OpenScaleDataProvider.kt
+++ b/src/app/src/main/java/com/health/openscale/sync/core/provider/OpenScaleDataProvider.kt
@@ -150,44 +150,31 @@ class OpenScaleDataProvider(
                 var fat: Float? = null
                 var water: Float? = null
                 var muscle: Float? = null
+                var bone = 0f
+                var lbm = 0f
+                var visceralFat = 0f
+                var waist = 0f
                 val userId = openScaleUser.id
 
                 for (i in 0 until record.columnCount) {
-                    if (record.getColumnName(i).equals("_ID")) {
-                        id = record.getInt(i)
-                    }
-
-                    if (record.getColumnName(i).equals("datetime")) {
-                        val timestamp = record.getLong(i)
-                        dateTime = Date(timestamp)
-                    }
-
-                    if (record.getColumnName(i).equals("weight")) {
-                        weight = roundFloat(record.getFloat(i))
-                    }
-
-                    if (record.getColumnName(i).equals("fat")) {
-                        fat = roundFloat(record.getFloat(i))
-                    }
-
-                    if (record.getColumnName(i).equals("water")) {
-                        water = roundFloat(record.getFloat(i))
-                    }
-
-                    if (record.getColumnName(i).equals("muscle")) {
-                        muscle = roundFloat(record.getFloat(i))
+                    when (record.getColumnName(i)) {
+                        "_ID"          -> id = record.getInt(i)
+                        "datetime"     -> dateTime = Date(record.getLong(i))
+                        "weight"       -> weight = roundFloat(record.getFloat(i))
+                        "fat"          -> fat = roundFloat(record.getFloat(i))
+                        "water"        -> water = roundFloat(record.getFloat(i))
+                        "muscle"       -> muscle = roundFloat(record.getFloat(i))
+                        "bone"         -> bone = roundFloat(record.getFloat(i))
+                        "lbm"          -> lbm = roundFloat(record.getFloat(i))
+                        "visceral_fat" -> visceralFat = roundFloat(record.getFloat(i))
+                        "waist"        -> waist = roundFloat(record.getFloat(i))
                     }
                 }
 
                 if (id != null && dateTime != null && weight != null && fat != null && water != null && muscle != null) {
                     val measurement = OpenScaleMeasurement(
-                        id,
-                        userId,
-                        dateTime,
-                        weight,
-                        fat,
-                        water,
-                        muscle
+                        id, userId, dateTime, weight, fat, water, muscle,
+                        bone, lbm, visceralFat, waist
                     )
 
                     measurements.add(measurement)

--- a/src/app/src/main/java/com/health/openscale/sync/core/service/InfluxDbService.kt
+++ b/src/app/src/main/java/com/health/openscale/sync/core/service/InfluxDbService.kt
@@ -1,0 +1,270 @@
+package com.health.openscale.sync.core.service
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.lifecycleScope
+import com.health.openscale.sync.R
+import com.health.openscale.sync.core.datatypes.OpenScaleMeasurement
+import com.health.openscale.sync.core.model.InfluxDbViewModel
+import com.health.openscale.sync.core.model.ViewModelInterface
+import com.health.openscale.sync.core.sync.InfluxDbSync
+import com.health.openscale.sync.core.utils.RetryQueue
+import kotlinx.coroutines.launch
+import okhttp3.OkHttpClient
+import java.util.Date
+import java.util.concurrent.TimeUnit
+
+class InfluxDbService(
+    private val context: Context,
+    private val sharedPreferences: SharedPreferences
+) : ServiceInterface(context) {
+
+    private val viewModel = InfluxDbViewModel(sharedPreferences)
+    private var influxSync: InfluxDbSync? = null
+    private val retryQueue = RetryQueue(context, "influxdb")
+
+    override fun viewModel(): ViewModelInterface = viewModel
+
+    override suspend fun init() {
+        connectInfluxDb()
+    }
+
+    private fun buildSync(): InfluxDbSync {
+        val client = OkHttpClient.Builder()
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .build()
+        return InfluxDbSync(
+            client = client,
+            baseUrl = viewModel.url.value?.trimEnd('/') ?: "",
+            isV2 = viewModel.isV2.value ?: true,
+            org = viewModel.org.value ?: "",
+            bucket = viewModel.bucket.value ?: "",
+            token = viewModel.token.value ?: "",
+            database = viewModel.database.value ?: "",
+            dbUsername = viewModel.dbUsername.value ?: "",
+            dbPassword = viewModel.dbPassword.value ?: "",
+            measurementName = viewModel.measurement.value ?: "openscale"
+        )
+    }
+
+    private suspend fun connectInfluxDb() {
+        if (!viewModel.syncEnabled.value) return
+        val url = viewModel.url.value ?: ""
+        if (url.isBlank()) {
+            setErrorMessage(context.getString(R.string.influxdb_url_empty_error))
+            return
+        }
+        viewModel.setConnecting(true)
+        val sync = buildSync()
+        val result = sync.testConnection()
+        viewModel.setConnecting(false)
+        when (result) {
+            is SyncResult.Success -> {
+                influxSync = sync
+                clearErrorMessage()
+                val pending = retryQueue.size()
+                drainQueue()
+                val msg = context.getString(R.string.influxdb_connected_text) +
+                    if (pending > 0) " ($pending ${context.getString(R.string.retry_queue_remaining)})" else ""
+                setInfoMessage(msg)
+            }
+            is SyncResult.Failure -> {
+                influxSync = null
+                setErrorMessage(result)
+            }
+        }
+    }
+
+    private suspend fun drainQueue() {
+        val sync = influxSync ?: return
+        val ops = retryQueue.peek()
+        if (ops.isEmpty()) return
+        var failedIndex = ops.size
+        for ((index, op) in ops.withIndex()) {
+            val result = when (op.type) {
+                "insert" -> sync.writePoint(op.toMeasurement())
+                "update" -> sync.writePoint(op.toMeasurement())
+                "delete" -> sync.deleteByTimestamp(Date(op.dateMs))
+                "clear"  -> sync.deleteAll()
+                else     -> SyncResult.Success(Unit)
+            }
+            if (result is SyncResult.Failure) {
+                failedIndex = index
+                break
+            }
+        }
+        retryQueue.replace(ops.subList(failedIndex, ops.size))
+    }
+
+    private suspend fun withSync(action: suspend (InfluxDbSync) -> SyncResult<Unit>): SyncResult<Unit> {
+        if (influxSync == null) connectInfluxDb()
+        val sync = influxSync ?: return SyncResult.Failure(SyncResult.ErrorType.UNKNOWN_ERROR, "Not connected")
+        return action(sync)
+    }
+
+    override suspend fun insert(measurement: OpenScaleMeasurement): SyncResult<Unit> {
+        val result = withSync { it.writePoint(measurement) }
+        if (result is SyncResult.Failure) retryQueue.enqueue(RetryQueue.insert(measurement))
+        return result
+    }
+
+    override suspend fun update(measurement: OpenScaleMeasurement): SyncResult<Unit> {
+        val result = withSync { it.writePoint(measurement) }
+        if (result is SyncResult.Failure) retryQueue.enqueue(RetryQueue.update(measurement))
+        return result
+    }
+
+    override suspend fun delete(date: Date): SyncResult<Unit> {
+        val result = withSync { it.deleteByTimestamp(date) }
+        if (result is SyncResult.Failure) retryQueue.enqueue(RetryQueue.delete(date))
+        return result
+    }
+
+    override suspend fun clear(): SyncResult<Unit> {
+        val result = withSync { it.deleteAll() }
+        if (result is SyncResult.Failure) retryQueue.enqueue(RetryQueue.clear())
+        return result
+    }
+
+    override suspend fun sync(measurements: List<OpenScaleMeasurement>): SyncResult<Unit> =
+        withSync { it.writePoints(measurements) }
+
+    @Composable
+    override fun composeSettings(activity: ComponentActivity) {
+        Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+            super.composeSettings(activity)
+
+            val urlState by viewModel.url.observeAsState("")
+            val isV2State by viewModel.isV2.observeAsState(true)
+            val orgState by viewModel.org.observeAsState("")
+            val bucketState by viewModel.bucket.observeAsState("")
+            val tokenState by viewModel.token.observeAsState("")
+            val databaseState by viewModel.database.observeAsState("")
+            val usernameState by viewModel.dbUsername.observeAsState("")
+            val passwordState by viewModel.dbPassword.observeAsState("")
+            val measurementState by viewModel.measurement.observeAsState("")
+            val connectingState by viewModel.connecting.observeAsState(false)
+
+            OutlinedTextField(
+                enabled = viewModel.syncEnabled.value,
+                modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                value = urlState,
+                onValueChange = { viewModel.setUrl(it) },
+                label = { Text(stringResource(R.string.influxdb_url_title)) },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri)
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    stringResource(R.string.influxdb_use_v2_title),
+                    modifier = Modifier.weight(1f)
+                )
+                Switch(
+                    enabled = viewModel.syncEnabled.value,
+                    checked = isV2State,
+                    onCheckedChange = { viewModel.setIsV2(it) }
+                )
+            }
+
+            if (isV2State) {
+                OutlinedTextField(
+                    enabled = viewModel.syncEnabled.value,
+                    modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                    value = orgState,
+                    onValueChange = { viewModel.setOrg(it) },
+                    label = { Text(stringResource(R.string.influxdb_org_title)) }
+                )
+                OutlinedTextField(
+                    enabled = viewModel.syncEnabled.value,
+                    modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                    value = bucketState,
+                    onValueChange = { viewModel.setBucket(it) },
+                    label = { Text(stringResource(R.string.influxdb_bucket_title)) }
+                )
+                OutlinedTextField(
+                    enabled = viewModel.syncEnabled.value,
+                    modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                    value = tokenState,
+                    onValueChange = { viewModel.setToken(it) },
+                    label = { Text(stringResource(R.string.influxdb_token_title)) },
+                    visualTransformation = PasswordVisualTransformation()
+                )
+            } else {
+                OutlinedTextField(
+                    enabled = viewModel.syncEnabled.value,
+                    modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                    value = databaseState,
+                    onValueChange = { viewModel.setDatabase(it) },
+                    label = { Text(stringResource(R.string.influxdb_database_title)) }
+                )
+                OutlinedTextField(
+                    enabled = viewModel.syncEnabled.value,
+                    modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                    value = usernameState,
+                    onValueChange = { viewModel.setDbUsername(it) },
+                    label = { Text(stringResource(R.string.influxdb_username_title)) }
+                )
+                OutlinedTextField(
+                    enabled = viewModel.syncEnabled.value,
+                    modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                    value = passwordState,
+                    onValueChange = { viewModel.setDbPassword(it) },
+                    label = { Text(stringResource(R.string.influxdb_password_title)) },
+                    visualTransformation = PasswordVisualTransformation()
+                )
+            }
+
+            OutlinedTextField(
+                enabled = viewModel.syncEnabled.value,
+                modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                value = measurementState,
+                onValueChange = { viewModel.setMeasurement(it) },
+                label = { Text(stringResource(R.string.influxdb_measurement_title)) }
+            )
+
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Button(
+                    enabled = viewModel.syncEnabled.value && !connectingState,
+                    onClick = { activity.lifecycleScope.launch { connectInfluxDb() } }
+                ) {
+                    Text(
+                        if (connectingState) stringResource(R.string.influxdb_connecting_text)
+                        else stringResource(R.string.influxdb_connect_button)
+                    )
+                }
+
+                val errorMessage by viewModel.errorMessage.observeAsState()
+                if (!errorMessage.isNullOrBlank() && viewModel.syncEnabled.value) {
+                    Text(errorMessage!!, color = Color.Red)
+                }
+            }
+        }
+    }
+}

--- a/src/app/src/main/java/com/health/openscale/sync/core/service/InfluxDbService.kt
+++ b/src/app/src/main/java/com/health/openscale/sync/core/service/InfluxDbService.kt
@@ -10,7 +10,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Switch
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -179,15 +181,19 @@ class InfluxDbService(
                 modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Text(
-                    stringResource(R.string.influxdb_use_v2_title),
-                    modifier = Modifier.weight(1f)
-                )
-                Switch(
+                RadioButton(
                     enabled = viewModel.syncEnabled.value,
-                    checked = isV2State,
-                    onCheckedChange = { viewModel.setIsV2(it) }
+                    selected = !isV2State,
+                    onClick = { viewModel.setIsV2(false) }
                 )
+                Text("v1")
+                Spacer(modifier = Modifier.width(16.dp))
+                RadioButton(
+                    enabled = viewModel.syncEnabled.value,
+                    selected = isV2State,
+                    onClick = { viewModel.setIsV2(true) }
+                )
+                Text("v2")
             }
 
             if (isV2State) {

--- a/src/app/src/main/java/com/health/openscale/sync/core/service/SyncService.kt
+++ b/src/app/src/main/java/com/health/openscale/sync/core/service/SyncService.kt
@@ -16,6 +16,7 @@ import com.health.openscale.sync.core.datatypes.OpenScaleMeasurement
 import com.health.openscale.sync.core.utils.LogManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -61,7 +62,9 @@ class SyncService : Service() {
         syncServiceList = arrayOf(
             HealthConnectService(applicationContext, prefs),
             MQTTService(applicationContext, prefs),
-            WgerService(applicationContext, prefs)
+            WgerService(applicationContext, prefs),
+            InfluxDbService(applicationContext, prefs),
+            WebhookService(applicationContext, prefs)
         )
 
         CoroutineScope(Dispatchers.Main).launch {
@@ -89,7 +92,7 @@ class SyncService : Service() {
         return START_STICKY
     }
 
-    protected fun onHandleIntent(intent: Intent?) {
+    private suspend fun onHandleIntent(intent: Intent?) {
         Timber.d("onHandleIntent extras: %s", intent.safeExtras())
 
         val openScaleUserId = prefs.getInt("selectedOpenScaleUserId", -1)
@@ -102,113 +105,119 @@ class SyncService : Service() {
             return
         }
 
-        for (syncService in syncServiceList) {
-            val vm = syncService.viewModel()
-            val name = vm.getName()
+        coroutineScope {
+            for (syncService in syncServiceList) {
+                val vm = syncService.viewModel()
+                val name = vm.getName()
 
-            if (!vm.syncEnabled.value) {
-                Timber.d("%s [disabled]", name)
-                continue
-            }
+                if (!vm.syncEnabled.value) {
+                    Timber.d("%s [disabled]", name)
+                    continue
+                }
 
-            Timber.d("%s [enabled]", name)
+                Timber.d("%s [enabled]", name)
 
-            when (mode) {
-                "insert", "update" -> {
-                    // Read all extras safely, no NPEs
-                    val id     = intent?.getIntExtra("id", 0) ?: 0
-                    val userId = intent?.getIntExtra("userId", 0) ?: 0
-                    val weight = roundFloat(intent?.getFloatExtra("weight", 0.0f) ?: 0f)
-                    val fat    = roundFloat(intent?.getFloatExtra("fat", 0.0f) ?: 0f)
-                    val water  = roundFloat(intent?.getFloatExtra("water", 0.0f) ?: 0f)
-                    val muscle = roundFloat(intent?.getFloatExtra("muscle", 0.0f) ?: 0f)
-                    val date   = Date(intent?.getLongExtra("date", 0L) ?: 0L)
+                when (mode) {
+                    "insert", "update" -> {
+                        // Read all extras safely, no NPEs
+                        val id          = intent?.getIntExtra("id", 0) ?: 0
+                        val userId      = intent?.getIntExtra("userId", 0) ?: 0
+                        val weight      = roundFloat(intent?.getFloatExtra("weight", 0.0f) ?: 0f)
+                        val fat         = roundFloat(intent?.getFloatExtra("fat", 0.0f) ?: 0f)
+                        val water       = roundFloat(intent?.getFloatExtra("water", 0.0f) ?: 0f)
+                        val muscle      = roundFloat(intent?.getFloatExtra("muscle", 0.0f) ?: 0f)
+                        val bone        = roundFloat(intent?.getFloatExtra("bone", 0.0f) ?: 0f)
+                        val lbm         = roundFloat(intent?.getFloatExtra("lbm", 0.0f) ?: 0f)
+                        val visceralFat = roundFloat(intent?.getFloatExtra("visceral_fat", 0.0f) ?: 0f)
+                        val waist       = roundFloat(intent?.getFloatExtra("waist", 0.0f) ?: 0f)
+                        val date        = Date(intent?.getLongExtra("date", 0L) ?: 0L)
 
-                    Timber.d(
-                        "SyncService %s id=%d userId=%d date=%s w=%.2f f=%.2f wa=%.2f m=%.2f",
-                        mode, id, userId, date, weight, fat, water, muscle
-                    )
+                        Timber.d(
+                            "SyncService %s id=%d userId=%d date=%s w=%.2f f=%.2f wa=%.2f m=%.2f bone=%.2f lbm=%.2f vf=%.2f waist=%.2f",
+                            mode, id, userId, date, weight, fat, water, muscle, bone, lbm, visceralFat, waist
+                        )
 
-                    if (userId == openScaleUserId) {
-                        CoroutineScope(Dispatchers.Main).launch {
-                            val m = OpenScaleMeasurement(id, userId, date, weight, fat, water, muscle)
-                            val t = System.nanoTime()
-                            val res = runCatching {
-                                if (mode == "insert") syncService.insert(m) else syncService.update(m)
-                            }.onFailure { e -> Timber.e(e, "%s.%s() threw", name, mode) }
+                        if (userId == openScaleUserId) {
+                            launch {
+                                val m = OpenScaleMeasurement(id, userId, date, weight, fat, water, muscle, bone, lbm, visceralFat, waist)
+                                val t = System.nanoTime()
+                                val res = runCatching {
+                                    if (mode == "insert") syncService.insert(m) else syncService.update(m)
+                                }.onFailure { e -> Timber.e(e, "%s.%s() threw", name, mode) }
+                                    .getOrNull()
+
+                                val ms = (System.nanoTime() - t) / 1_000_000
+                                when (res) {
+                                    is SyncResult.Success -> {
+                                        vm.setLastSync(Instant.now())
+                                        val fmt = DateFormat.getDateFormat(applicationContext).format(date)
+                                        val msg = if (mode == "insert")
+                                            getString(R.string.sync_service_measurement_inserted_info, weight, fmt)
+                                        else
+                                            getString(R.string.sync_service_measurement_updated_info, weight, fmt)
+                                        syncService.setInfoMessage(msg)
+                                        Timber.d("%s.%s() success in %d ms", name, mode, ms)
+                                    }
+                                    is SyncResult.Failure -> {
+                                        syncService.setErrorMessage(res)
+                                        Timber.e("(%s.%s) %s in %d ms", name, mode, res.message, ms)
+                                    }
+                                    null -> {
+                                        Timber.w("%s.%s() returned null in %d ms", name, mode, ms)
+                                    }
+                                }
+                            }
+                        } else {
+                            Timber.w("userId mismatch: intent=%d, selected=%d -> skipping", userId, openScaleUserId)
+                        }
+                    }
+
+                    "delete" -> {
+                        val date = Date(intent?.getLongExtra("date", 0L) ?: 0L)
+                        Timber.d("SyncService delete for date=%s", date)
+
+                        launch {
+                            val res = runCatching { syncService.delete(date) }
+                                .onFailure { e -> Timber.e(e, "%s.delete() threw", name) }
                                 .getOrNull()
-
-                            val ms = (System.nanoTime() - t) / 1_000_000
                             when (res) {
                                 is SyncResult.Success -> {
                                     vm.setLastSync(Instant.now())
                                     val fmt = DateFormat.getDateFormat(applicationContext).format(date)
-                                    val msg = if (mode == "insert")
-                                        getString(R.string.sync_service_measurement_inserted_info, weight, fmt)
-                                    else
-                                        getString(R.string.sync_service_measurement_updated_info, weight, fmt)
-                                    syncService.setInfoMessage(msg)
-                                    Timber.d("%s.%s() success in %d ms", name, mode, ms)
+                                    syncService.setInfoMessage(getString(R.string.sync_service_measurement_deleted_info, fmt))
+                                    Timber.d("%s.delete() success", name)
                                 }
                                 is SyncResult.Failure -> {
                                     syncService.setErrorMessage(res)
-                                    Timber.e("(%s.%s) %s in %d ms", name, mode, res.message, ms)
+                                    Timber.e("(%s.delete) %s", name, res.message)
                                 }
                                 null -> {
-                                    Timber.w("%s.%s() returned null in %d ms", name, mode, ms)
+                                    Timber.w("%s.delete() returned null", name)
                                 }
                             }
                         }
-                    } else {
-                        Timber.w("userId mismatch: intent=%d, selected=%d -> skipping", userId, openScaleUserId)
                     }
-                }
 
-                "delete" -> {
-                    val date = Date(intent?.getLongExtra("date", 0L) ?: 0L)
-                    Timber.d("SyncService delete for date=%s", date)
+                    "clear" -> {
+                        Timber.d("SyncService clear command received")
 
-                    CoroutineScope(Dispatchers.Main).launch {
-                        val res = runCatching { syncService.delete(date) }
-                            .onFailure { e -> Timber.e(e, "%s.delete() threw", name) }
-                            .getOrNull()
-                        when (res) {
-                            is SyncResult.Success -> {
-                                vm.setLastSync(Instant.now())
-                                val fmt = DateFormat.getDateFormat(applicationContext).format(date)
-                                syncService.setInfoMessage(getString(R.string.sync_service_measurement_deleted_info, fmt))
-                                Timber.d("%s.delete() success", name)
-                            }
-                            is SyncResult.Failure -> {
-                                syncService.setErrorMessage(res)
-                                Timber.e("(%s.delete) %s", name, res.message)
-                            }
-                            null -> {
-                                Timber.w("%s.delete() returned null", name)
-                            }
-                        }
-                    }
-                }
-
-                "clear" -> {
-                    Timber.d("SyncService clear command received")
-
-                    CoroutineScope(Dispatchers.Main).launch {
-                        val res = runCatching { syncService.clear() }
-                            .onFailure { e -> Timber.e(e, "%s.clear() threw", name) }
-                            .getOrNull()
-                        when (res) {
-                            is SyncResult.Success -> {
-                                vm.setLastSync(Instant.now())
-                                syncService.setInfoMessage(getString(R.string.sync_service_measurement_cleared_info))
-                                Timber.d("%s.clear() success", name)
-                            }
-                            is SyncResult.Failure -> {
-                                syncService.setErrorMessage(res)
-                                Timber.e("(%s.clear) %s", name, res.message)
-                            }
-                            null -> {
-                                Timber.w("%s.clear() returned null", name)
+                        launch {
+                            val res = runCatching { syncService.clear() }
+                                .onFailure { e -> Timber.e(e, "%s.clear() threw", name) }
+                                .getOrNull()
+                            when (res) {
+                                is SyncResult.Success -> {
+                                    vm.setLastSync(Instant.now())
+                                    syncService.setInfoMessage(getString(R.string.sync_service_measurement_cleared_info))
+                                    Timber.d("%s.clear() success", name)
+                                }
+                                is SyncResult.Failure -> {
+                                    syncService.setErrorMessage(res)
+                                    Timber.e("(%s.clear) %s", name, res.message)
+                                }
+                                null -> {
+                                    Timber.w("%s.clear() returned null", name)
+                                }
                             }
                         }
                     }

--- a/src/app/src/main/java/com/health/openscale/sync/core/service/SyncService.kt
+++ b/src/app/src/main/java/com/health/openscale/sync/core/service/SyncService.kt
@@ -120,26 +120,22 @@ class SyncService : Service() {
                 when (mode) {
                     "insert", "update" -> {
                         // Read all extras safely, no NPEs
-                        val id          = intent?.getIntExtra("id", 0) ?: 0
-                        val userId      = intent?.getIntExtra("userId", 0) ?: 0
-                        val weight      = roundFloat(intent?.getFloatExtra("weight", 0.0f) ?: 0f)
-                        val fat         = roundFloat(intent?.getFloatExtra("fat", 0.0f) ?: 0f)
-                        val water       = roundFloat(intent?.getFloatExtra("water", 0.0f) ?: 0f)
-                        val muscle      = roundFloat(intent?.getFloatExtra("muscle", 0.0f) ?: 0f)
-                        val bone        = roundFloat(intent?.getFloatExtra("bone", 0.0f) ?: 0f)
-                        val lbm         = roundFloat(intent?.getFloatExtra("lbm", 0.0f) ?: 0f)
-                        val visceralFat = roundFloat(intent?.getFloatExtra("visceral_fat", 0.0f) ?: 0f)
-                        val waist       = roundFloat(intent?.getFloatExtra("waist", 0.0f) ?: 0f)
-                        val date        = Date(intent?.getLongExtra("date", 0L) ?: 0L)
+                        val id     = intent?.getIntExtra("id", 0) ?: 0
+                        val userId = intent?.getIntExtra("userId", 0) ?: 0
+                        val weight = roundFloat(intent?.getFloatExtra("weight", 0.0f) ?: 0f)
+                        val fat    = roundFloat(intent?.getFloatExtra("fat", 0.0f) ?: 0f)
+                        val water  = roundFloat(intent?.getFloatExtra("water", 0.0f) ?: 0f)
+                        val muscle = roundFloat(intent?.getFloatExtra("muscle", 0.0f) ?: 0f)
+                        val date   = Date(intent?.getLongExtra("date", 0L) ?: 0L)
 
                         Timber.d(
-                            "SyncService %s id=%d userId=%d date=%s w=%.2f f=%.2f wa=%.2f m=%.2f bone=%.2f lbm=%.2f vf=%.2f waist=%.2f",
-                            mode, id, userId, date, weight, fat, water, muscle, bone, lbm, visceralFat, waist
+                            "SyncService %s id=%d userId=%d date=%s w=%.2f f=%.2f wa=%.2f m=%.2f",
+                            mode, id, userId, date, weight, fat, water, muscle
                         )
 
                         if (userId == openScaleUserId) {
                             launch {
-                                val m = OpenScaleMeasurement(id, userId, date, weight, fat, water, muscle, bone, lbm, visceralFat, waist)
+                                val m = OpenScaleMeasurement(id, userId, date, weight, fat, water, muscle)
                                 val t = System.nanoTime()
                                 val res = runCatching {
                                     if (mode == "insert") syncService.insert(m) else syncService.update(m)
@@ -294,6 +290,7 @@ class SyncService : Service() {
         }
 
         for (k in keys) {
+            @Suppress("DEPRECATION")
             val raw = runCatching { b.get(k) }.getOrNull()
             val entry = when {
                 REDACT_KEYS.any { k.contains(it, ignoreCase = true) } -> "$k=«redacted»"

--- a/src/app/src/main/java/com/health/openscale/sync/core/service/WebhookService.kt
+++ b/src/app/src/main/java/com/health/openscale/sync/core/service/WebhookService.kt
@@ -1,0 +1,149 @@
+package com.health.openscale.sync.core.service
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import com.health.openscale.sync.R
+import com.health.openscale.sync.core.datatypes.OpenScaleMeasurement
+import com.health.openscale.sync.core.model.ViewModelInterface
+import com.health.openscale.sync.core.model.WebhookViewModel
+import com.health.openscale.sync.core.sync.WebhookSync
+import com.health.openscale.sync.core.utils.RetryQueue
+import okhttp3.OkHttpClient
+import java.util.Date
+import java.util.concurrent.TimeUnit
+
+class WebhookService(
+    private val context: Context,
+    private val sharedPreferences: SharedPreferences
+) : ServiceInterface(context) {
+
+    private val viewModel = WebhookViewModel(sharedPreferences)
+    private var webhookSync: WebhookSync? = null
+    private val retryQueue = RetryQueue(context, "webhook")
+    private var lastUrl: String? = null
+    private var lastAuthHeader: String? = null
+
+    override fun viewModel(): ViewModelInterface = viewModel
+
+    override suspend fun init() {
+        initWebhook()
+        drainQueue()
+    }
+
+    private fun initWebhook() {
+        if (!viewModel.syncEnabled.value) return
+        val url = viewModel.url.value ?: ""
+        val authHeader = viewModel.authHeader.value ?: ""
+        if (url.isBlank()) return
+        if (webhookSync != null && url == lastUrl && authHeader == lastAuthHeader) return
+        val client = OkHttpClient.Builder()
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .build()
+        webhookSync = WebhookSync(client = client, url = url, authHeader = authHeader)
+        lastUrl = url
+        lastAuthHeader = authHeader
+    }
+
+    private suspend fun drainQueue() {
+        val sync = webhookSync ?: return
+        val ops = retryQueue.peek()
+        if (ops.isEmpty()) return
+        var failedIndex = ops.size
+        for ((index, op) in ops.withIndex()) {
+            val result = when (op.type) {
+                "insert" -> sync.insert(op.toMeasurement())
+                "update" -> sync.update(op.toMeasurement())
+                "delete" -> sync.delete(Date(op.dateMs))
+                "clear"  -> sync.clear()
+                else     -> SyncResult.Success(Unit)
+            }
+            if (result is SyncResult.Failure) {
+                failedIndex = index
+                break
+            }
+        }
+        retryQueue.replace(ops.subList(failedIndex, ops.size))
+    }
+
+    private suspend fun withSync(action: suspend (WebhookSync) -> SyncResult<Unit>): SyncResult<Unit> {
+        initWebhook()
+        val sync = webhookSync ?: return SyncResult.Failure(SyncResult.ErrorType.UNKNOWN_ERROR, "Not configured")
+        val result = action(sync)
+        if (result is SyncResult.Success) clearErrorMessage()
+        return result
+    }
+
+    override suspend fun insert(measurement: OpenScaleMeasurement): SyncResult<Unit> {
+        val result = withSync { it.insert(measurement) }
+        if (result is SyncResult.Failure) retryQueue.enqueue(RetryQueue.insert(measurement))
+        return result
+    }
+
+    override suspend fun update(measurement: OpenScaleMeasurement): SyncResult<Unit> {
+        val result = withSync { it.update(measurement) }
+        if (result is SyncResult.Failure) retryQueue.enqueue(RetryQueue.update(measurement))
+        return result
+    }
+
+    override suspend fun delete(date: Date): SyncResult<Unit> {
+        val result = withSync { it.delete(date) }
+        if (result is SyncResult.Failure) retryQueue.enqueue(RetryQueue.delete(date))
+        return result
+    }
+
+    override suspend fun clear(): SyncResult<Unit> {
+        val result = withSync { it.clear() }
+        if (result is SyncResult.Failure) retryQueue.enqueue(RetryQueue.clear())
+        return result
+    }
+
+    override suspend fun sync(measurements: List<OpenScaleMeasurement>): SyncResult<Unit> =
+        withSync { it.fullSync(measurements) }
+
+    @Composable
+    override fun composeSettings(activity: ComponentActivity) {
+        Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+            super.composeSettings(activity)
+
+            val urlState by viewModel.url.observeAsState("")
+            val authHeaderState by viewModel.authHeader.observeAsState("")
+
+            OutlinedTextField(
+                enabled = viewModel.syncEnabled.value,
+                modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                value = urlState,
+                onValueChange = { viewModel.setUrl(it) },
+                label = { Text(stringResource(R.string.webhook_url_title)) }
+            )
+
+            OutlinedTextField(
+                enabled = viewModel.syncEnabled.value,
+                modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                value = authHeaderState,
+                onValueChange = { viewModel.setAuthHeader(it) },
+                label = { Text(stringResource(R.string.webhook_auth_header_title)) },
+                visualTransformation = PasswordVisualTransformation()
+            )
+
+            val errorMessage by viewModel.errorMessage.observeAsState()
+            if (!errorMessage.isNullOrBlank() && viewModel.syncEnabled.value) {
+                Text(errorMessage!!, color = Color.Red)
+            }
+        }
+    }
+}

--- a/src/app/src/main/java/com/health/openscale/sync/core/sync/InfluxDbSync.kt
+++ b/src/app/src/main/java/com/health/openscale/sync/core/sync/InfluxDbSync.kt
@@ -27,11 +27,12 @@ class InfluxDbSync(
     private val measurementName: String
 ) : SyncInterface() {
 
-    private fun toLineProtocol(m: OpenScaleMeasurement): String =
-        "$measurementName,source=openscale" +
-        " weight=${m.weight},body_fat=${m.fat},water=${m.water},muscle=${m.muscle}" +
-        ",bone=${m.bone},lbm=${m.lbm},visceral_fat=${m.visceralFat},waist=${m.waist}" +
-        " ${m.date.time * 1_000_000L}"
+    private fun toLineProtocol(m: OpenScaleMeasurement): String {
+        val extra = m.extraFields.entries.joinToString("") { ",${it.key}=${it.value}" }
+        return "$measurementName,source=openscale" +
+            " weight=${m.weight},body_fat=${m.fat},water=${m.water},muscle=${m.muscle}" +
+            "$extra ${m.date.time * 1_000_000L}"
+    }
 
     private fun Request.Builder.addAuth(): Request.Builder = when {
         isV2 -> addHeader("Authorization", "Token $token")

--- a/src/app/src/main/java/com/health/openscale/sync/core/sync/InfluxDbSync.kt
+++ b/src/app/src/main/java/com/health/openscale/sync/core/sync/InfluxDbSync.kt
@@ -1,0 +1,102 @@
+package com.health.openscale.sync.core.sync
+
+import com.health.openscale.sync.core.datatypes.OpenScaleMeasurement
+import com.health.openscale.sync.core.service.SyncResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.Credentials
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+import java.util.Date
+
+class InfluxDbSync(
+    private val client: OkHttpClient,
+    private val baseUrl: String,
+    private val isV2: Boolean,
+    private val org: String,
+    private val bucket: String,
+    private val token: String,
+    private val database: String,
+    private val dbUsername: String,
+    private val dbPassword: String,
+    private val measurementName: String
+) : SyncInterface() {
+
+    private fun toLineProtocol(m: OpenScaleMeasurement): String =
+        "$measurementName,source=openscale" +
+        " weight=${m.weight},body_fat=${m.fat},water=${m.water},muscle=${m.muscle}" +
+        ",bone=${m.bone},lbm=${m.lbm},visceral_fat=${m.visceralFat},waist=${m.waist}" +
+        " ${m.date.time * 1_000_000L}"
+
+    private fun Request.Builder.addAuth(): Request.Builder = when {
+        isV2 -> addHeader("Authorization", "Token $token")
+        dbUsername.isNotBlank() -> addHeader("Authorization", Credentials.basic(dbUsername, dbPassword))
+        else -> this
+    }
+
+    suspend fun writePoints(measurements: List<OpenScaleMeasurement>): SyncResult<Unit> = withContext(Dispatchers.IO) {
+        if (measurements.isEmpty()) return@withContext SyncResult.Success(Unit)
+        val body = measurements.joinToString("\n") { toLineProtocol(it) }
+        val url = if (isV2)
+            "$baseUrl/api/v2/write?org=${enc(org)}&bucket=${enc(bucket)}&precision=ns"
+        else
+            "$baseUrl/write?db=${enc(database)}&precision=ns"
+        runRequest(Request.Builder().url(url).addAuth()
+            .post(body.toRequestBody("text/plain; charset=utf-8".toMediaType())).build())
+    }
+
+    suspend fun writePoint(measurement: OpenScaleMeasurement): SyncResult<Unit> =
+        writePoints(listOf(measurement))
+
+    suspend fun deleteByTimestamp(date: Date): SyncResult<Unit> = withContext(Dispatchers.IO) {
+        if (isV2) {
+            val instant = Instant.ofEpochMilli(date.time)
+            val start = DateTimeFormatter.ISO_INSTANT.format(instant.truncatedTo(ChronoUnit.SECONDS))
+            val stop = DateTimeFormatter.ISO_INSTANT.format(instant.truncatedTo(ChronoUnit.SECONDS).plusSeconds(1))
+            val json = """{"start":"$start","stop":"$stop","predicate":"_measurement=\"$measurementName\""}"""
+            val url = "$baseUrl/api/v2/delete?org=${enc(org)}&bucket=${enc(bucket)}"
+            runRequest(Request.Builder().url(url).addAuth()
+                .post(json.toRequestBody("application/json".toMediaType())).build())
+        } else {
+            val tsNs = date.time * 1_000_000L
+            val q = """DELETE FROM "$measurementName" WHERE time = $tsNs"""
+            val url = "$baseUrl/query?db=${enc(database)}"
+            runRequest(Request.Builder().url(url).addAuth()
+                .post("q=${enc(q)}".toRequestBody("application/x-www-form-urlencoded".toMediaType())).build())
+        }
+    }
+
+    suspend fun deleteAll(): SyncResult<Unit> = withContext(Dispatchers.IO) {
+        if (isV2) {
+            val json = """{"start":"1970-01-01T00:00:00Z","stop":"2100-01-01T00:00:00Z","predicate":"_measurement=\"$measurementName\""}"""
+            val url = "$baseUrl/api/v2/delete?org=${enc(org)}&bucket=${enc(bucket)}"
+            runRequest(Request.Builder().url(url).addAuth()
+                .post(json.toRequestBody("application/json".toMediaType())).build())
+        } else {
+            val url = "$baseUrl/query?db=${enc(database)}"
+            runRequest(Request.Builder().url(url).addAuth()
+                .post("q=${enc("""DELETE FROM "$measurementName"""")}".toRequestBody("application/x-www-form-urlencoded".toMediaType())).build())
+        }
+    }
+
+    suspend fun testConnection(): SyncResult<Unit> = withContext(Dispatchers.IO) {
+        runRequest(Request.Builder().url("$baseUrl/ping").addAuth().get().build())
+    }
+
+    private fun runRequest(request: Request): SyncResult<Unit> = try {
+        client.newCall(request).execute().use { response ->
+            if (response.isSuccessful || response.code == 204) SyncResult.Success(Unit)
+            else SyncResult.Failure(SyncResult.ErrorType.API_ERROR,
+                "HTTP ${response.code}: ${response.body?.string()?.take(200)}")
+        }
+    } catch (e: Exception) {
+        SyncResult.Failure(SyncResult.ErrorType.UNKNOWN_ERROR, cause = e)
+    }
+
+    private fun enc(value: String): String = java.net.URLEncoder.encode(value, "UTF-8")
+}

--- a/src/app/src/main/java/com/health/openscale/sync/core/sync/WebhookSync.kt
+++ b/src/app/src/main/java/com/health/openscale/sync/core/sync/WebhookSync.kt
@@ -1,0 +1,71 @@
+package com.health.openscale.sync.core.sync
+
+import com.google.gson.Gson
+import com.health.openscale.sync.core.datatypes.OpenScaleMeasurement
+import com.health.openscale.sync.core.service.SyncResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+class WebhookSync(
+    private val client: OkHttpClient,
+    private val url: String,
+    private val authHeader: String
+) : SyncInterface() {
+
+    private val gson = Gson()
+    private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply {
+        timeZone = TimeZone.getTimeZone("UTC")
+    }
+
+    private fun measurementToMap(m: OpenScaleMeasurement): MutableMap<String, Any> = mutableMapOf(
+        "id" to m.id,
+        "userId" to m.userId,
+        "date" to dateFormat.format(m.date),
+        "weight" to m.weight,
+        "fat" to m.fat,
+        "water" to m.water,
+        "muscle" to m.muscle
+    )
+
+    suspend fun fullSync(measurements: List<OpenScaleMeasurement>): SyncResult<Unit> =
+        post(gson.toJson(mapOf(
+            "event" to "fullSync",
+            "measurements" to measurements.map { measurementToMap(it) }
+        )))
+
+    suspend fun insert(measurement: OpenScaleMeasurement): SyncResult<Unit> =
+        post(gson.toJson(measurementToMap(measurement).also { it["event"] = "insert" }))
+
+    suspend fun update(measurement: OpenScaleMeasurement): SyncResult<Unit> =
+        post(gson.toJson(measurementToMap(measurement).also { it["event"] = "update" }))
+
+    suspend fun delete(date: Date): SyncResult<Unit> =
+        post(gson.toJson(mapOf("event" to "delete", "date" to dateFormat.format(date))))
+
+    suspend fun clear(): SyncResult<Unit> =
+        post(gson.toJson(mapOf("event" to "clear")))
+
+    private suspend fun post(json: String): SyncResult<Unit> = withContext(Dispatchers.IO) {
+        try {
+            val builder = Request.Builder()
+                .url(url)
+                .post(json.toRequestBody("application/json; charset=utf-8".toMediaType()))
+            if (authHeader.isNotBlank()) builder.addHeader("Authorization", authHeader)
+            client.newCall(builder.build()).execute().use { response ->
+                if (response.isSuccessful) SyncResult.Success(Unit)
+                else SyncResult.Failure(SyncResult.ErrorType.API_ERROR,
+                    "HTTP ${response.code}: ${response.body?.string()?.take(200)}")
+            }
+        } catch (e: Exception) {
+            SyncResult.Failure(SyncResult.ErrorType.UNKNOWN_ERROR, cause = e)
+        }
+    }
+}

--- a/src/app/src/main/java/com/health/openscale/sync/core/sync/WebhookSync.kt
+++ b/src/app/src/main/java/com/health/openscale/sync/core/sync/WebhookSync.kt
@@ -25,15 +25,16 @@ class WebhookSync(
         timeZone = TimeZone.getTimeZone("UTC")
     }
 
-    private fun measurementToMap(m: OpenScaleMeasurement): MutableMap<String, Any> = mutableMapOf(
-        "id" to m.id,
-        "userId" to m.userId,
-        "date" to dateFormat.format(m.date),
-        "weight" to m.weight,
-        "fat" to m.fat,
-        "water" to m.water,
-        "muscle" to m.muscle
-    )
+    private fun measurementToMap(m: OpenScaleMeasurement): MutableMap<String, Any> =
+        mutableMapOf<String, Any>(
+            "id" to m.id,
+            "userId" to m.userId,
+            "date" to dateFormat.format(m.date),
+            "weight" to m.weight,
+            "fat" to m.fat,
+            "water" to m.water,
+            "muscle" to m.muscle
+        ).also { map -> m.extraFields.forEach { (k, v) -> map[k] = v } }
 
     suspend fun fullSync(measurements: List<OpenScaleMeasurement>): SyncResult<Unit> =
         post(gson.toJson(mapOf(

--- a/src/app/src/main/java/com/health/openscale/sync/core/utils/RetryQueue.kt
+++ b/src/app/src/main/java/com/health/openscale/sync/core/utils/RetryQueue.kt
@@ -17,19 +17,20 @@ class RetryQueue(context: Context, serviceKey: String) {
         val weight: Float = 0f,
         val fat: Float = 0f,
         val water: Float = 0f,
-        val muscle: Float = 0f
+        val muscle: Float = 0f,
+        val extraFields: Map<String, Float> = emptyMap()
     ) {
-        fun toMeasurement() = OpenScaleMeasurement(id, userId, Date(dateMs), weight, fat, water, muscle)
+        fun toMeasurement() = OpenScaleMeasurement(id, userId, Date(dateMs), weight, fat, water, muscle, extraFields)
     }
 
     companion object {
         private const val MAX_SIZE = 500
 
         fun insert(m: OpenScaleMeasurement) =
-            PendingOp("insert", m.id, m.userId, m.date.time, m.weight, m.fat, m.water, m.muscle)
+            PendingOp("insert", m.id, m.userId, m.date.time, m.weight, m.fat, m.water, m.muscle, m.extraFields)
 
         fun update(m: OpenScaleMeasurement) =
-            PendingOp("update", m.id, m.userId, m.date.time, m.weight, m.fat, m.water, m.muscle)
+            PendingOp("update", m.id, m.userId, m.date.time, m.weight, m.fat, m.water, m.muscle, m.extraFields)
 
         fun delete(date: Date) = PendingOp("delete", dateMs = date.time)
 

--- a/src/app/src/main/java/com/health/openscale/sync/core/utils/RetryQueue.kt
+++ b/src/app/src/main/java/com/health/openscale/sync/core/utils/RetryQueue.kt
@@ -1,0 +1,66 @@
+package com.health.openscale.sync.core.utils
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.health.openscale.sync.core.datatypes.OpenScaleMeasurement
+import java.util.Date
+
+class RetryQueue(context: Context, serviceKey: String) {
+
+    data class PendingOp(
+        val type: String,
+        val id: Int = 0,
+        val userId: Int = 0,
+        val dateMs: Long = 0L,
+        val weight: Float = 0f,
+        val fat: Float = 0f,
+        val water: Float = 0f,
+        val muscle: Float = 0f
+    ) {
+        fun toMeasurement() = OpenScaleMeasurement(id, userId, Date(dateMs), weight, fat, water, muscle)
+    }
+
+    companion object {
+        private const val MAX_SIZE = 500
+
+        fun insert(m: OpenScaleMeasurement) =
+            PendingOp("insert", m.id, m.userId, m.date.time, m.weight, m.fat, m.water, m.muscle)
+
+        fun update(m: OpenScaleMeasurement) =
+            PendingOp("update", m.id, m.userId, m.date.time, m.weight, m.fat, m.water, m.muscle)
+
+        fun delete(date: Date) = PendingOp("delete", dateMs = date.time)
+
+        fun clear() = PendingOp("clear")
+    }
+
+    private val prefs: SharedPreferences =
+        context.getSharedPreferences("retry_queue_$serviceKey", Context.MODE_PRIVATE)
+    private val gson = Gson()
+    private val listType = object : TypeToken<List<PendingOp>>() {}.type
+
+    @Synchronized
+    fun enqueue(op: PendingOp) {
+        val current = if (op.type == "clear") mutableListOf() else peek().toMutableList()
+        current.add(op)
+        if (current.size > MAX_SIZE) current.subList(0, current.size - MAX_SIZE).clear()
+        prefs.edit().putString("queue", gson.toJson(current)).apply()
+    }
+
+    @Synchronized
+    fun peek(): List<PendingOp> {
+        val json = prefs.getString("queue", null) ?: return emptyList()
+        return runCatching { gson.fromJson<List<PendingOp>>(json, listType) ?: emptyList() }
+            .getOrElse { emptyList() }
+    }
+
+    @Synchronized
+    fun replace(ops: List<PendingOp>) {
+        prefs.edit().putString("queue", gson.toJson(ops)).apply()
+    }
+
+    fun isEmpty(): Boolean = peek().isEmpty()
+    fun size(): Int = peek().size
+}

--- a/src/app/src/main/java/com/health/openscale/sync/gui/MainActivity.kt
+++ b/src/app/src/main/java/com/health/openscale/sync/gui/MainActivity.kt
@@ -113,9 +113,11 @@ import com.health.openscale.sync.R
 import com.health.openscale.sync.core.provider.OpenScaleDataProvider
 import com.health.openscale.sync.core.provider.OpenScaleProvider
 import com.health.openscale.sync.core.service.HealthConnectService
+import com.health.openscale.sync.core.service.InfluxDbService
 import com.health.openscale.sync.core.service.MQTTService
 import com.health.openscale.sync.core.service.ServiceInterface
 import com.health.openscale.sync.core.service.SyncResult
+import com.health.openscale.sync.core.service.WebhookService
 import com.health.openscale.sync.core.service.WgerService
 import com.health.openscale.sync.core.utils.LogManager
 import com.health.openscale.sync.gui.theme.OpenScaleSyncTheme
@@ -167,7 +169,9 @@ class MainActivity : AppCompatActivity() {
         syncServiceList = listOf(
             HealthConnectService(applicationContext, sharedPreferences),
             MQTTService(applicationContext, sharedPreferences),
-            WgerService(applicationContext, sharedPreferences)
+            WgerService(applicationContext, sharedPreferences),
+            InfluxDbService(applicationContext, sharedPreferences),
+            WebhookService(applicationContext, sharedPreferences)
         )
 
         for (syncService in syncServiceList) {
@@ -518,7 +522,7 @@ class MainActivity : AppCompatActivity() {
                                 type = "text/plain"
                                 putExtra(Intent.EXTRA_TITLE, "openscale_sync_log.txt")
                             }
-                            (ctx as MainActivity).saveLogLauncher.launch(intent)
+                            ctx.saveLogLauncher.launch(intent)
                         }
                     ) {
                         Text(stringResource(id = R.string.logging_export_button))

--- a/src/app/src/main/res/drawable/ic_influxdb.xml
+++ b/src/app/src/main/res/drawable/ic_influxdb.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M2 20h20v-4H2v4zm2-3h2v2H4v-2zM2 4v4h20V4H2zm4 3H4V5h2v2zm-4 7h20v-4H2v4zm2-3h2v2H4v-2z"/>
+</vector>

--- a/src/app/src/main/res/drawable/ic_webhook.xml
+++ b/src/app/src/main/res/drawable/ic_webhook.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/>
+</vector>

--- a/src/app/src/main/res/values-de/strings.xml
+++ b/src/app/src/main/res/values-de/strings.xml
@@ -61,4 +61,23 @@
     <string name="wger_connect_to_wger_button">Mit Wger verbinden</string>
 
     <string name="realtime_sync_update_required_snackbar_text">Für die Echtzeit-Synchronisation aktualisiere openScale bitte auf Version 2.5.5 oder die neueste Entwickler Version.</string>
+
+    <string name="influxdb_url_title">URL (z.B. http://192.168.1.100:8086)</string>
+    <string name="influxdb_use_v2_title">InfluxDB v2 API verwenden</string>
+    <string name="influxdb_org_title">Organisation</string>
+    <string name="influxdb_bucket_title">Bucket</string>
+    <string name="influxdb_token_title">Token</string>
+    <string name="influxdb_database_title">Datenbank</string>
+    <string name="influxdb_username_title">Benutzername</string>
+    <string name="influxdb_password_title">Passwort</string>
+    <string name="influxdb_measurement_title">Measurement-Name</string>
+    <string name="influxdb_connect_button">Verbindung testen</string>
+    <string name="influxdb_connecting_text">Verbinde …</string>
+    <string name="influxdb_connected_text">InfluxDB-Verbindung erfolgreich</string>
+    <string name="influxdb_url_empty_error">InfluxDB-URL darf nicht leer sein</string>
+
+    <string name="webhook_url_title">Webhook-URL</string>
+    <string name="webhook_auth_header_title">Autorisierungs-Header (optional)</string>
+
+    <string name="retry_queue_remaining">ausstehend in der Warteschlange</string>
 </resources>

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -60,4 +60,21 @@
     <string name="wger_connect_to_wger_button">Connect to Wger</string>
 
     <string name="realtime_sync_update_required_snackbar_text">For Real-time synchronization, please update openScale to version 2.5.5 or to the latest developer version.</string>
+
+    <string name="influxdb_url_title">URL (e.g. http://192.168.1.100:8086)</string>
+    <string name="influxdb_use_v2_title">Use InfluxDB v2 API</string>
+    <string name="influxdb_org_title">Organization</string>
+    <string name="influxdb_bucket_title">Bucket</string>
+    <string name="influxdb_token_title">Token</string>
+    <string name="influxdb_database_title">Database</string>
+    <string name="influxdb_username_title">Username</string>
+    <string name="influxdb_password_title">Password</string>
+    <string name="influxdb_measurement_title">Measurement name</string>
+    <string name="influxdb_connect_button">Test connection</string>
+    <string name="influxdb_connecting_text">Connecting …</string>
+    <string name="influxdb_connected_text">InfluxDB connection successful</string>
+    <string name="influxdb_url_empty_error">InfluxDB URL must not be empty</string>
+    <string name="webhook_url_title">Webhook URL</string>
+    <string name="webhook_auth_header_title">Authorization header (optional)</string>
+    <string name="retry_queue_remaining">pending in queue</string>
 </resources>


### PR DESCRIPTION
Merge influxdb_sync: Add InfluxDB and Webhook sync backends

- InfluxDB sync (v1 and v2 API) with line protocol, offline retry queue,
  and v1/v2 radio button selection in settings
- Webhook sync with JSON payload and offline retry queue
- OpenScaleMeasurement extended with dynamic extraFields map — all
  numeric ContentProvider columns are captured automatically, supporting
  any scale regardless of which body metrics it measures
- SyncService: coroutineScope ensures HTTP requests complete before
  service stops; adds POST_NOTIFICATIONS permission for Android 13+
- .gitignore: exclude .vscode/ and .claude/


