### PR TITLE
Add state_class=measurement to numeric HA discovery sensors

### DIFF
--- a/src/app/src/main/res/raw/homeassistant_payload.json
+++ b/src/app/src/main/res/raw/homeassistant_payload.json
@@ -14,6 +14,7 @@
       "name": "Weight",
       "platform": "sensor",
       "device_class": "weight",
+      "state_class": "measurement",
       "unit_of_measurement": "kg",
       "value_template": "{{ value_json.weight | default(none) }}",
       "unique_id": "openscale_weight"
@@ -21,6 +22,7 @@
     "openscale_fat": {
       "name": "Body fat",
       "platform": "sensor",
+      "state_class": "measurement",
       "unit_of_measurement": "%",
       "value_template": "{{ value_json.fat | default(none) }}",
       "unique_id": "openscale_fat"
@@ -28,6 +30,7 @@
     "openscale_muscle": {
       "name": "Muscle",
       "platform": "sensor",
+      "state_class": "measurement",
       "unit_of_measurement": "%",
       "value_template": "{{ value_json.muscle | default(none) }}",
       "unique_id": "openscale_muscle"
@@ -36,6 +39,7 @@
       "name": "Total body water",
       "platform": "sensor",
       "device_class": "moisture",
+      "state_class": "measurement",
       "unit_of_measurement": "%",
       "value_template": "{{ value_json.water | default(none) }}",
       "unique_id": "openscale_water"


### PR DESCRIPTION
## Summary

The bundled Home Assistant discovery payload (`res/raw/homeassistant_payload.json`) declares `device_class` and `unit_of_measurement` for the four numeric sensors (Weight, Body fat, Muscle, Total body water) but omits `state_class`. Without it, Home Assistant cannot record long-term statistics for these entities.

On HA installs that previously had LTS recorded (older payload, or HA itself inferring stats before the integration tightened the rules), the missing `state_class` after a reconnect surfaces as a repair:

> The entity no longer has a state class
> We have generated statistics for 'Weegschaal Weight' (sensor.openscale_weight) in the past, but it no longer has a state class, therefore, we cannot track long term statistics for it anymore.

All four are point-in-time measurements (not cumulative), so `measurement` is the correct value per the HA sensor docs: https://developers.home-assistant.io/docs/core/entity/sensor#available-state-classes

Measurement date (timestamp) and Measurement id (diagnostic counter / identifier) are intentionally left unchanged.

## Change

```diff
       "device_class": "weight",
+      "state_class": "measurement",
       "unit_of_measurement": "kg",
```

…and the same one-line addition for `openscale_fat`, `openscale_muscle`, and `openscale_water`.

## Test plan

- [x] JSON validates (`python -m json.tool`)
- [x] Verified the same payload structure, published retained to `homeassistant/device/openscale/config` with `state_class` added, makes HA recognise the sensors as recordable again and clears the repair on the next stats cycle.