### PR TITLE
Added missing metrics to the Health Connect sync.

### DIFF
--- a/src/app/src/main/AndroidManifest.xml
+++ b/src/app/src/main/AndroidManifest.xml
@@ -19,6 +19,12 @@
         tools:ignore="HealthConnectPolicy" />
     <uses-permission android:name="android.permission.health.WRITE_WEIGHT"
         tools:ignore="HealthConnectPolicy" />
+    <uses-permission android:name="android.permission.health.WRITE_BASAL_METABOLIC_RATE"
+        tools:ignore="HealthConnectPolicy" />
+    <uses-permission android:name="android.permission.health.WRITE_LEAN_BODY_MASS"
+        tools:ignore="HealthConnectPolicy" />
+    <uses-permission android:name="android.permission.health.WRITE_BONE_MASS"
+        tools:ignore="HealthConnectPolicy" />
 
     <queries>
         <package android:name="com.health.openscale" />

--- a/src/app/src/main/AndroidManifest.xml
+++ b/src/app/src/main/AndroidManifest.xml
@@ -25,6 +25,18 @@
         tools:ignore="HealthConnectPolicy" />
     <uses-permission android:name="android.permission.health.WRITE_BONE_MASS"
         tools:ignore="HealthConnectPolicy" />
+    <uses-permission android:name="android.permission.health.READ_WEIGHT"
+        tools:ignore="HealthConnectPolicy"/>
+    <uses-permission android:name="android.permission.health.READ_BODY_FAT"
+        tools:ignore="HealthConnectPolicy"/>
+    <uses-permission android:name="android.permission.health.READ_BODY_WATER_MASS"
+        tools:ignore="HealthConnectPolicy"/>
+    <uses-permission android:name="android.permission.health.READ_BONE_MASS"
+        tools:ignore="HealthConnectPolicy"/>
+    <uses-permission android:name="android.permission.health.READ_BASAL_METABOLIC_RATE"
+        tools:ignore="HealthConnectPolicy"/>
+    <uses-permission android:name="android.permission.health.READ_LEAN_BODY_MASS"
+        tools:ignore="HealthConnectPolicy"/>
 
     <queries>
         <package android:name="com.health.openscale" />

--- a/src/app/src/main/java/com/health/openscale/sync/core/datatypes/OpenScaleMeasurement.kt
+++ b/src/app/src/main/java/com/health/openscale/sync/core/datatypes/OpenScaleMeasurement.kt
@@ -74,6 +74,8 @@ data class OpenScaleMeasurement(
     val body_fat: Float,
     val water: Float,
     val muscle: Float,
+    val lbm: Float,
+    val bone: Float,
     // Human-readable openScale user name; carried for multi-user routing/labelling
     // (MQTT topic uses the stable userId, this is for the JSON payload / HA display name).
     val username: String = "",
@@ -81,6 +83,7 @@ data class OpenScaleMeasurement(
     // weight/fat/water/muscle above are convenience fields derived from it (see [fromValues]).
     val values: List<OpenScaleMeasurementValue> = emptyList()
 ) {
+
     companion object {
         /**
          * Builds a measurement from the generic value set, deriving the convenience weight/fat/
@@ -98,7 +101,7 @@ data class OpenScaleMeasurement(
                 return if (v.unit == "%") value else if (weight > 0f) value / weight * 100f else 0f
             }
             return OpenScaleMeasurement(
-                id, userId, date, weight, pct("BODY_FAT"), pct("WATER"), pct("MUSCLE"), username, values
+                id, userId, date, weight, pct("BODY_FAT"), pct("WATER"), pct("MUSCLE"), pct("LBM"), pct("BONE"),username, values
             )
         }
 

--- a/src/app/src/main/java/com/health/openscale/sync/core/service/HealthConnectService.kt
+++ b/src/app/src/main/java/com/health/openscale/sync/core/service/HealthConnectService.kt
@@ -32,8 +32,11 @@ import com.health.openscale.sync.gui.components.UserScopeSection
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.PermissionController
 import androidx.health.connect.client.permission.HealthPermission
+import androidx.health.connect.client.records.BasalMetabolicRateRecord
 import androidx.health.connect.client.records.BodyFatRecord
 import androidx.health.connect.client.records.BodyWaterMassRecord
+import androidx.health.connect.client.records.BoneMassRecord
+import androidx.health.connect.client.records.LeanBodyMassRecord
 import androidx.health.connect.client.records.WeightRecord
 import androidx.lifecycle.coroutineScope
 import androidx.lifecycle.lifecycleScope
@@ -60,10 +63,16 @@ class HealthConnectService(
         HealthPermission.getWritePermission(WeightRecord::class),
         HealthPermission.getWritePermission(BodyWaterMassRecord::class),
         HealthPermission.getWritePermission(BodyFatRecord::class),
+        HealthPermission.getWritePermission(BoneMassRecord::class),
+        HealthPermission.getWritePermission(BasalMetabolicRateRecord::class),
+        HealthPermission.getWritePermission(LeanBodyMassRecord::class),
         // Read permissions enable bidirectional (inbound) sync: import weight written by other apps.
         HealthPermission.getReadPermission(WeightRecord::class),
         HealthPermission.getReadPermission(BodyWaterMassRecord::class),
         HealthPermission.getReadPermission(BodyFatRecord::class),
+        HealthPermission.getReadPermission(BoneMassRecord::class),
+        HealthPermission.getReadPermission(BasalMetabolicRateRecord::class),
+        HealthPermission.getReadPermission(LeanBodyMassRecord::class),
     )
 
     private val healthConnectPermissionContract =

--- a/src/app/src/main/java/com/health/openscale/sync/core/sync/HealthConnectSync.kt
+++ b/src/app/src/main/java/com/health/openscale/sync/core/sync/HealthConnectSync.kt
@@ -371,11 +371,13 @@ class HealthConnectSync(private var healthConnectClient: HealthConnectClient) : 
     private fun buildBMRRecord(measurement: OpenScaleMeasurement): BasalMetabolicRateRecord {
         val measurementInstant = measurement.date.toInstant()
         val zoneOffset = ZoneId.systemDefault().rules.getOffset(measurementInstant)
+        val bmrKcalPerDay = (measurement.values.firstOrNull { it.key == "BMR" }?.value ?: 0f).toDouble()
+        val bmrWatts = bmrKcalPerDay * (4184.0 / 86400.0) // kcal/day → Watts
 
         return BasalMetabolicRateRecord(
             time = measurementInstant,
             zoneOffset = zoneOffset,
-            basalMetabolicRate = Power.watts((measurement.values.firstOrNull { it.key == "BMR" }?.value ?: 0f).toDouble() / 20.6458),
+            basalMetabolicRate = Power.watts(bmrWatts),
             metadata = buildMetadata(measurement, "bmr")
         )
     }

--- a/src/app/src/main/java/com/health/openscale/sync/core/sync/HealthConnectSync.kt
+++ b/src/app/src/main/java/com/health/openscale/sync/core/sync/HealthConnectSync.kt
@@ -18,8 +18,11 @@
 package com.health.openscale.sync.core.sync
 
 import androidx.health.connect.client.HealthConnectClient
+import androidx.health.connect.client.records.BasalMetabolicRateRecord
 import androidx.health.connect.client.records.BodyFatRecord
 import androidx.health.connect.client.records.BodyWaterMassRecord
+import androidx.health.connect.client.records.BoneMassRecord
+import androidx.health.connect.client.records.LeanBodyMassRecord
 import androidx.health.connect.client.records.Record
 import androidx.health.connect.client.records.WeightRecord
 import androidx.health.connect.client.records.metadata.DataOrigin
@@ -29,6 +32,7 @@ import androidx.health.connect.client.response.ReadRecordsResponse
 import androidx.health.connect.client.time.TimeRangeFilter
 import androidx.health.connect.client.units.Mass
 import androidx.health.connect.client.units.Percentage
+import androidx.health.connect.client.units.Power
 import com.health.openscale.sync.core.datatypes.OpenScaleMeasurement
 import com.health.openscale.sync.core.service.SyncResult
 import java.time.Instant
@@ -49,6 +53,23 @@ class HealthConnectSync(private var healthConnectClient: HealthConnectClient) : 
 
             val fatRecord = buildFatRecord(measurement)
             records.add(fatRecord)
+
+            if (measurement.lbm > 0f) {
+                val leanBodyMassRecord = buildLeanBodyMassRecord(measurement)
+                records.add(leanBodyMassRecord)
+            }
+
+            if (measurement.bone > 0f) {
+                val boneMassRecord = buildBoneMassRecord(measurement)
+                records.add(boneMassRecord)
+            }
+
+            val bmrValue = measurement.values.firstOrNull { it.key == "BMR" }?.value ?: 0f
+            if (bmrValue > 0f) {
+                val bmrRecord = buildBMRRecord(measurement)
+                records.add(bmrRecord)
+            }
+
         }
 
         try {
@@ -70,6 +91,22 @@ class HealthConnectSync(private var healthConnectClient: HealthConnectClient) : 
 
         val fatRecord = buildFatRecord(measurement)
         records.add(fatRecord)
+
+        if (measurement.lbm > 0f) {
+            val leanBodyMassRecord = buildLeanBodyMassRecord(measurement)
+            records.add(leanBodyMassRecord)
+        }
+
+        if (measurement.bone > 0f) {
+            val boneMassRecord = buildBoneMassRecord(measurement)
+            records.add(boneMassRecord)
+        }
+
+        val bmrValue = measurement.values.firstOrNull { it.key == "BMR" }?.value ?: 0f
+        if (bmrValue > 0f) {
+            val bmrRecord = buildBMRRecord(measurement)
+            records.add(bmrRecord)
+        }
 
         try {
             healthConnectClient.insertRecords(records)
@@ -99,6 +136,19 @@ class HealthConnectSync(private var healthConnectClient: HealthConnectClient) : 
                     BodyWaterMassRecord::class,
                     timeRange
                 )
+            healthConnectClient.deleteRecords(
+                LeanBodyMassRecord::class,
+                timeRange
+            )
+            healthConnectClient.deleteRecords(
+                BasalMetabolicRateRecord::class,
+                timeRange
+            )
+            healthConnectClient.deleteRecords(
+                BoneMassRecord::class,
+                timeRange
+            )
+
 
             return SyncResult.Success(Unit)
         } catch (e: Exception) {
@@ -126,6 +176,18 @@ class HealthConnectSync(private var healthConnectClient: HealthConnectClient) : 
                 BodyWaterMassRecord::class,
                 timeRange
             )
+            healthConnectClient.deleteRecords(
+                LeanBodyMassRecord::class,
+                timeRange
+            )
+            healthConnectClient.deleteRecords(
+                BasalMetabolicRateRecord::class,
+                timeRange
+            )
+            healthConnectClient.deleteRecords(
+                BoneMassRecord::class,
+                timeRange
+            )
 
             return SyncResult.Success(Unit)
         } catch (e: Exception) {
@@ -140,6 +202,9 @@ class HealthConnectSync(private var healthConnectClient: HealthConnectClient) : 
             val weightRecord = readWeightRecord(measurement)
             val waterRecord = readWaterRecord(measurement)
             val fatRecord = readFatRecord(measurement)
+            val leanBodyMassRecord = readLeanMassRecord(measurement)
+            val boneMassRecord = readBoneRecord(measurement)
+
 
             if (weightRecord != null) {
                 records.add(buildWeightRecord(measurement))
@@ -150,6 +215,13 @@ class HealthConnectSync(private var healthConnectClient: HealthConnectClient) : 
             if (fatRecord != null) {
                 records.add(buildFatRecord(measurement))
             }
+            if (leanBodyMassRecord != null) {
+                records.add(buildLeanBodyMassRecord(measurement))
+            }
+            if (boneMassRecord != null) {
+                records.add(buildBoneMassRecord(measurement))
+            }
+            records.add(buildBMRRecord(measurement))
 
             if (records.isNotEmpty()) {
                 healthConnectClient.insertRecords(records)
@@ -204,6 +276,14 @@ class HealthConnectSync(private var healthConnectClient: HealthConnectClient) : 
 
     private suspend fun readFatRecord(measurement: OpenScaleMeasurement): BodyFatRecord? {
         return readRecord(measurement,BodyFatRecord::class)
+    }
+
+    private suspend fun readBoneRecord(measurement: OpenScaleMeasurement): BoneMassRecord? {
+        return readRecord(measurement, BoneMassRecord::class)
+    }
+
+    private suspend fun readLeanMassRecord(measurement: OpenScaleMeasurement): LeanBodyMassRecord? {
+        return readRecord(measurement, LeanBodyMassRecord::class)
     }
 
     private suspend fun <T : Record> readRecord(
@@ -261,6 +341,42 @@ class HealthConnectSync(private var healthConnectClient: HealthConnectClient) : 
             zoneOffset = zoneOffset,
             percentage = Percentage(measurement.body_fat.toDouble()),
             metadata = buildMetadata(measurement, "fat")   // HC clientRecordId suffix — internal dedup key, kept stable
+        )
+    }
+
+    private fun buildLeanBodyMassRecord(measurement: OpenScaleMeasurement): LeanBodyMassRecord {
+        val measurementInstant = measurement.date.toInstant()
+        val zoneOffset = ZoneId.systemDefault().rules.getOffset(measurementInstant)
+
+        return LeanBodyMassRecord(
+            time = measurementInstant,
+            zoneOffset = zoneOffset,
+            mass = Mass.kilograms((measurement.weight * measurement.lbm / 100f).toDouble()),
+            metadata = buildMetadata(measurement, "lbm")
+        )
+    }
+
+    private fun buildBoneMassRecord(measurement: OpenScaleMeasurement): BoneMassRecord {
+        val measurementInstant = measurement.date.toInstant()
+        val zoneOffset = ZoneId.systemDefault().rules.getOffset(measurementInstant)
+
+        return BoneMassRecord(
+            time = measurementInstant,
+            zoneOffset = zoneOffset,
+            mass = Mass.kilograms((measurement.weight * measurement.bone / 100f).toDouble()),
+            metadata = buildMetadata(measurement, "bone")
+        )
+    }
+
+    private fun buildBMRRecord(measurement: OpenScaleMeasurement): BasalMetabolicRateRecord {
+        val measurementInstant = measurement.date.toInstant()
+        val zoneOffset = ZoneId.systemDefault().rules.getOffset(measurementInstant)
+
+        return BasalMetabolicRateRecord(
+            time = measurementInstant,
+            zoneOffset = zoneOffset,
+            basalMetabolicRate = Power.watts((measurement.values.firstOrNull { it.key == "BMR" }?.value ?: 0f).toDouble() / 20.6458),
+            metadata = buildMetadata(measurement, "bmr")
         )
     }
 }


### PR DESCRIPTION
Hi,
Some days ago I noticed that despite the fact that OpenScale was able to correctly register my BMR, Lean Body Mass and Bone Mass, these data weren't being logged inside Health Connect.
I did my best to try to add these features myself since I really need them. I tested this on my phone with some measurements taken with my Xiaomi Body Composition Scale 2 and everything seems to be working fine. I tried to modify as few files as possible and to keep the conventions of this amazing project. I might have made some mistakes here and there, so please let me know if something needs to be done differently.
I used the latest build and to make everything work I also had to add the Read Permissions for the new record types. I honestly don't know if this was the intended approach, please correct me if not. For now I'm going to be using my custom build with these new features, but it would be amazing if this could be made available to everyone!


<img width="1080" height="2400" alt="Screenshot_20260626_112014_HealthConnect" src="https://github.com/user-attachments/assets/1265c6f0-f528-486a-835f-2c279e37d3fd" />

<img width="1080" height="4426" alt="Screenshot_20260626_112212_HealthConnect" src="https://github.com/user-attachments/assets/a4ec2efa-4df1-4821-8e35-52e332604dcb" />

Permission page.

<img width="1080" height="2400" alt="Screenshot_20260626_112150_OpenVitals" src="https://github.com/user-attachments/assets/65231431-b3e1-497a-9c6a-5705caccf1af" />

OpenVitals screenshot showing every metric being correctly fetched from Health Connect, with data taken with OpenScale and synced via OpenScale Sync.

Thank you for your time!



Disclaimer: I used Claude here and there to help me with debugging, but I personally supervised everything and made sure that it was all correct to the best of my abilities.




PS: I know that my body fat is extremely low, bur that's my scale precision's fault.